### PR TITLE
Fix CTR_MACRO

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -93,7 +93,7 @@ extern "C"
     }
 }
 
-u8 ALIGN(8) statbuf[0x800] = {0};
+u8 CTR_ALIGN(8) statbuf[0x800] = {0};
 int main() {
 
     int nmbActiveHandles;

--- a/source/nfc.cpp
+++ b/source/nfc.cpp
@@ -7,8 +7,8 @@ extern "C" {
 #include "pmdbgext.h"
 }
 
-static u8 ALIGN(8) hidThreadStack[0x1000];
-static u8 ALIGN(8) threadStack[0x1000];
+static u8 CTR_ALIGN(8) hidThreadStack[0x1000];
+static u8 CTR_ALIGN(8) threadStack[0x1000];
 
 extern "C"
 {


### PR DESCRIPTION
Fixes CTR_MACRO so it can be compiled with newer versions of libctru (2.3.0)